### PR TITLE
feat: 为应用配置页、日志查询页添加了搜索栏. ref #64

### DIFF
--- a/assets/src/components/tree-search-version/index.jsx
+++ b/assets/src/components/tree-search-version/index.jsx
@@ -44,33 +44,14 @@ const getMasterStatus = (tree, statusMap, nodeKey) => {
 //    |- Node-1
 //    |- Node-2
 // |- Folder
-const Tree = (props) => {
+const TreeSearchVersion = (props) => {
   const {
     tree = [], loading, activeKey, onSelect,
-    defaultActiveKey, treeStatusChange
+    defaultActiveKey, keywords
   } = props;
 
-  // 文件夹的开关状态，默认所有都是关
+  // 文件夹的开关状态，默认所有都是开，为了自动展开
   const [folderStatus, setFolderStatus] = useState({});
-
-  useEffect(() => {
-    // 在搜索栏选中某个元素时，进行定位
-    // 如果该文件父级的文件夹未打开，则打开它
-    if (!activeKey) {
-      return;
-    }
-    const masterKey = getMaster(tree, activeKey);
-    console.log(masterKey);
-    if (!masterKey) {
-      folderStatus[activeKey.key] = true;
-      setFolderStatus({...folderStatus});
-
-      return;
-    }
-
-    folderStatus[masterKey.key] = true;
-    setFolderStatus({...folderStatus});
-  }, [treeStatusChange]);
 
   useEffect(() => {
     const one = tree.find(item => item.key === defaultActiveKey);
@@ -117,21 +98,24 @@ const Tree = (props) => {
             if (isSlave) {
               const isOpen = getMasterStatus(tree, folderStatus, item.key);
 
-              if (!isOpen) {
+              if (isOpen) {
                 return true;
               }
+            }
+
+            let itemText = item.title;
+
+            if (itemText.indexOf(keywords) >= 0) {
+              itemText = itemText.replace(
+                keywords, "<span style='background-color:rgb(233, 242, 250);" +
+                  "color: red; padding:0px 2px;'>" + keywords + '</span>'
+              );
             }
 
             return (
               <li
                 key={item.key}
                 onClick={() => {
-                  if (isMaster) {
-                    folderStatus[item.key] = !folderStatus[item.key];
-                    setFolderStatus({...folderStatus});
-
-                    return;
-                  }
                   item.key && onSelect(item.key);
                 }}
                 className={
@@ -144,19 +128,16 @@ const Tree = (props) => {
                 }
               >
                 {
-                  (isMaster && folderStatus[item.key]) && (
+                  (isMaster && !folderStatus[item.key]) && (
                     <FolderOpenOutlined />
                   )
                 }
                 {
-                  (isMaster && !folderStatus[item.key]) && (
+                  (isMaster && folderStatus[item.key]) && (
                     <FolderOutlined />
                   )
                 }
-                <span className="title">
-                  {
-                    item.title
-                  }
+                <span className="title" dangerouslySetInnerHTML={{__html: itemText}}>
                 </span>
               </li>
             );
@@ -167,7 +148,7 @@ const Tree = (props) => {
   );
 };
 
-Tree.propTypes = {
+TreeSearchVersion.propTypes = {
   loading: PropTypes.bool,
   tree: PropTypes.arrayOf(PropTypes.shape({
     title: PropTypes.string,
@@ -178,7 +159,7 @@ Tree.propTypes = {
   activeKey: PropTypes.string,
   defaultActiveKey: PropTypes.string,
   onSelect: PropTypes.func,
-  treeStatusChange: PropTypes.number
+  keywords: PropTypes.string
 };
 
-export default Tree;
+export default TreeSearchVersion;

--- a/assets/src/components/tree-search-version/index.less
+++ b/assets/src/components/tree-search-version/index.less
@@ -1,0 +1,50 @@
+@import '../../index.less';
+
+.tree-ul {
+  margin: 0;
+  list-style: none;
+  padding: 0;
+  width: 232px;
+  overflow: auto;
+  white-space: nowrap;
+  height: calc(100vh - 130px);
+
+  li {
+    margin-top: 4px;
+  }
+
+  .master {
+    height: 36px;
+    line-height: 36px;
+    font-weight: bold;
+    cursor: pointer;
+
+    .title {
+      margin-left: 16px;
+      -webkit-touch-callout: none;
+      -webkit-user-select: none;
+      -khtml-user-select: none;
+      -moz-user-select: none;
+      -ms-user-select: none;
+      user-select: none;
+    }
+
+  }
+
+  .active {
+    color: @primary-color;
+  }
+
+  .slave {
+    height: 20px;
+    margin-bottom: 8px;
+    padding-left: 28px;
+    line-height: 20px;
+    cursor: pointer;
+
+    &:hover {
+      background-color: rgb(233, 242, 250);
+      font-weight: bold;
+    }
+  }
+}

--- a/assets/src/pages/app-config/coms/app-list.jsx
+++ b/assets/src/pages/app-config/coms/app-list.jsx
@@ -1,12 +1,15 @@
-import React from 'react';
+import React, {useState} from 'react';
 import PropTypes from 'prop-types';
 import {useRequest} from '@lib/hooks';
 import notification from '@coms/notification';
 import Tree from '@coms/tree';
 import api from '@api/index';
 import {ADMIN_APP_CODE} from '@lib/consts';
-
 import {connect} from 'dva';
+import SearchTree from './search-tree';
+
+
+import './search-module.less';
 
 const USER_APP = '用户应用';
 const SYSTEM_APP = '系统应用';
@@ -66,6 +69,14 @@ const getAppTree = (appNames = []) => {
 
 const AppList = (props) => {
   const {currentClusterCode, onSelect, activeAppName} = props;
+  /**
+   * 搜索框的各个状态，分别是列表树的元素、上一次搜索的字符串、
+   * 用户输入的字符串和选中次数（用来通知外层的树改变形态）
+   */
+  const [fileSearchItem, setFileSearchItem] = useState([]);
+  const [lastSearchString, setLastSearchString] = useState('');
+  const [searchInputString, setSearchInputString] = useState('');
+  const [searchTimes, setSearchTimes] = useState(0);
 
   const {result: appList, loading} = useRequest({
     request: async () => {
@@ -86,14 +97,106 @@ const AppList = (props) => {
     defaultValue: []
   }, [currentClusterCode]);
 
+  const onSelectSearchTreeItem = (filepath) => {
+    onSelect(filepath);
+    setSearchTimes(searchTimes + 1);
+    setFileSearchResultList('');
+  };
+
+  // 文件搜索框的下拉列表
+  const FileSearchResultList = () => {
+    return (
+      <div className="file-search-result-list">
+        {
+          fileSearchItem.length !== 0 ?
+            <SearchTree
+              tree={fileSearchItem}
+              loading={loading}
+              onSelect={onSelectSearchTreeItem}
+              keywords={lastSearchString}
+            /> :
+            lastSearchString === '' ?
+              null : <div className="file-search-result-item">没有数据</div>
+        }
+      </div>
+    );
+  };
+
+  // 用户输入改变时，改变搜索到的数据
+  const setFileSearchResultList = (v) => {
+    if (v === '') {
+      setFileSearchItem([]);
+      setLastSearchString('');
+      setSearchInputString('');
+
+      return null;
+    }
+    if (v.target.value === '') {
+      setFileSearchItem([]);
+      setLastSearchString(v.target.value);
+      setSearchInputString('');
+
+      return null;
+    }
+    setSearchInputString(v.target.value);
+    // 搜寻到的item列表原型
+    let tmpSearchItemList = [];
+
+    if (v.target.value.includes(lastSearchString) && lastSearchString !== '') {
+      tmpSearchItemList = fileSearchItem.filter((item) => {
+        return item.title.includes(v.target.value);
+      });
+    } else {
+      tmpSearchItemList = getAppTree(appList.map(app => app.name)).filter((item) => {
+        return item.title.includes(v.target.value);
+      });
+    }
+
+    // 用来去重的set
+    const tmpSet = new Set();
+    // 最终将要setstate的列表
+    const finalSearchItemList = [];
+
+    // 先将每一个元素全部都正确地插进数组中，最后再进行排序处理
+    for (let cc = 0; cc < tmpSearchItemList.length; cc++) {
+      let nowNode = tmpSearchItemList[cc];
+
+      while (nowNode) {
+        if (tmpSet.has(nowNode.key)) {
+          break;
+        }
+        nowNode.filepath = (nowNode.parent ? nowNode.parent : '') + '/' + nowNode.key;
+        finalSearchItemList.push(nowNode);
+        tmpSet.add(nowNode.key);
+        nowNode = getAppTree(appList.map(app => app.name)).find((item) => {
+          return item.key === nowNode.parent;
+        });
+      }
+    }
+    setFileSearchItem(finalSearchItemList.sort((a, b) => {
+      return a.filepath > b.filepath;
+    }));
+    setLastSearchString(v.target.value);
+  };
+
   return (
-    <Tree
-      loading={loading}
-      onSelect={onSelect}
-      tree={getAppTree(appList.map(app => app.name))}
-      activeKey={activeAppName}
-      defaultActiveKey={USER_APP}
-    />
+    <div>
+      <input
+        value={searchInputString}
+        className="file-search-bar"
+        placeholder="文件搜索"
+        onChange={(e) => setFileSearchResultList(e)}
+      />
+      <FileSearchResultList></FileSearchResultList>
+      <Tree
+        loading={loading}
+        onSelect={onSelect}
+        tree={getAppTree(appList.map(app => app.name))}
+        activeKey={activeAppName}
+        defaultActiveKey={USER_APP}
+        treeStatusChange={searchTimes}
+      />
+    </div>
   );
 };
 

--- a/assets/src/pages/app-config/coms/search-module.less
+++ b/assets/src/pages/app-config/coms/search-module.less
@@ -1,0 +1,23 @@
+.file-search-bar {
+  width: 212px;
+  margin-top: 10px;
+  outline-style: none;
+  border: 1px solid #ccc; 
+  border-radius: 3px;
+  padding: 2px 5px;
+  &:focus{
+    border-color: #66afe9;
+    outline: 0;
+    -webkit-box-shadow: inset 0 1px 1px rgba(0,0,0,.075),0 0 8px rgba(102,175,233,.6);
+    box-shadow: inset 0 1px 1px rgba(0,0,0,.075),0 0 8px rgba(102,175,233,.6)
+  }
+}
+
+.file-search-result-list {
+  position: absolute;
+  background-color: white;
+  padding-left: 4px;
+  width: 212px;
+  z-index: 100;
+}
+  

--- a/assets/src/pages/app-config/coms/search-tree.jsx
+++ b/assets/src/pages/app-config/coms/search-tree.jsx
@@ -1,0 +1,23 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import TreeSearchVersion from '@coms/tree-search-version';
+
+const SearchTree = (props) => {
+  return (
+    <TreeSearchVersion {...props} />
+  );
+};
+
+SearchTree.propTypes = {
+  loading: PropTypes.bool,
+  tree: PropTypes.arrayOf(PropTypes.shape({
+    title: PropTypes.string,
+    level: PropTypes.number,
+    icon: PropTypes.string,
+    key: PropTypes.string
+  })),
+  onSelect: PropTypes.func,
+  keywords: PropTypes.string
+};
+
+export default SearchTree;

--- a/assets/src/pages/log/coms/search-tree/index.jsx
+++ b/assets/src/pages/log/coms/search-tree/index.jsx
@@ -1,0 +1,23 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import TreeSearchVersion from '@coms/tree-search-version';
+
+const SearchTree = (props) => {
+  return (
+    <TreeSearchVersion {...props} />
+  );
+};
+
+SearchTree.propTypes = {
+  loading: PropTypes.bool,
+  tree: PropTypes.arrayOf(PropTypes.shape({
+    title: PropTypes.string,
+    level: PropTypes.number,
+    icon: PropTypes.string,
+    key: PropTypes.string
+  })),
+  onSelect: PropTypes.func,
+  keywords: PropTypes.string
+};
+
+export default SearchTree;

--- a/assets/src/pages/log/index.jsx
+++ b/assets/src/pages/log/index.jsx
@@ -10,6 +10,7 @@ import s2q from '@lib/search-to-query';
 import msgParser from '@lib/msg-parser';
 import filepaths2tree from '@lib/filepath-to-tree';
 
+import SearchTree from './coms/search-tree';
 import FileTree from './coms/file-tree';
 import LogPanel from '../../components/log-panel';
 
@@ -24,6 +25,14 @@ const Log = (props) => {
   const [tree, setTree] = useState([]);
   const [activeLog, setActiveLog] = useState(DEFAULT_ACTIVE_LOG);
   const [initing, setIniting] = useState(true);
+  /**
+   * 搜索框的各个状态，分别是列表树的元素、上一次搜索的字符串、
+   * 用户输入的字符串和选中次数（用来通知外层的树改变形态）
+   */
+  const [fileSearchItem, setFileSearchItem] = useState([]);
+  const [lastSearchString, setLastSearchString] = useState('');
+  const [searchInputString, setSearchInputString] = useState('');
+  const [searchTimes, setSearchTimes] = useState(0);
 
   // 获取日志列表
   const getLogFiles = async (currentClusterCode) => {
@@ -90,14 +99,124 @@ const Log = (props) => {
 
   const onSelectFile = (filepath) => {
     setQuery(props.location, props.dispatch, {logFilepath: filepath});
-
     setActiveLog(filepath);
+  };
+
+  const onSelectSearchTreeItem = (filepath) => {
+    onSelectFile(filepath);
+    setSearchTimes(searchTimes + 1);
+    setFileSearchResultList('');
+  };
+
+  // 文件搜索框的下拉列表
+  const FileSearchResultList = () => {
+    return (
+      <div className="file-search-result-list">
+        {
+          fileSearchItem.length !== 0 ?
+            <SearchTree
+              tree={fileSearchItem}
+              loading={filesLoading}
+              onSelect={onSelectSearchTreeItem}
+              keywords={lastSearchString}
+            /> :
+            lastSearchString === '' ?
+              null : <div className="file-search-result-item">没有数据</div>
+        }
+      </div>
+    );
+  };
+
+  // 用户输入改变时，改变搜索到的数据
+  const setFileSearchResultList = (v) => {
+    if (v === '') {
+      setFileSearchItem([]);
+      setLastSearchString('');
+      setSearchInputString('');
+
+      return null;
+    }
+    if (v.target.value === '') {
+      setFileSearchItem([]);
+      setLastSearchString(v.target.value);
+      setSearchInputString('');
+
+      return null;
+    }
+    setSearchInputString(v.target.value);
+    // 搜寻到的item列表原型
+    let tmpSearchItemList = [];
+
+    if (v.target.value.includes(lastSearchString) && lastSearchString !== '') {
+      tmpSearchItemList = fileSearchItem.filter((item) => {
+        return item.title.includes(v.target.value);
+      });
+    } else {
+      tmpSearchItemList = tree.filter((item) => {
+        return item.title.includes(v.target.value);
+      });
+    }
+
+    // 用来去重的set
+    const tmpSet = new Set();
+    // 最终将要setstate的列表
+    const finalSearchItemList = [];
+
+    // 先将每一个元素全部都正确地插进数组中，最后再进行排序处理
+    for (let cc = 0; cc < tmpSearchItemList.length; cc++) {
+      let nowNode = tmpSearchItemList[cc];
+
+      while (nowNode) {
+        if (tmpSet.has(nowNode.key)) {
+          break;
+        }
+        finalSearchItemList.push(nowNode);
+        tmpSet.add(nowNode.key);
+        nowNode = tree.find((item) => {
+          return item.key === nowNode.parent;
+        });
+      }
+    }
+
+    setFileSearchItem(finalSearchItemList.sort((a, b) => {
+      // 由于根目录文件的特殊路径，这里需要特殊处理
+      if (a.key === '系统日志') {
+        return false;
+      }
+      if (b.key === '系统日志') {
+        return true;
+      }
+      if (a.parent === '系统日志' && b.parent !== '系统日志') {
+        return false;
+      }
+      if (b.parent === '系统日志' && a.parent !== '系统日志') {
+        return true;
+      }
+      if (a.parent === '系统日志' && b.parent === '系统日志') {
+        return a.key > b.key;
+      }
+
+      return a.key > b.key;
+    }));
+    setLastSearchString(v.target.value);
   };
 
   return (
     <div>
       <div className="page-left-side">
         <div className="list-title">日志列表</div>
+        {
+          !initing &&
+            <div>
+              <input
+                value={searchInputString}
+                className="file-search-bar"
+                placeholder="文件搜索"
+                onChange={(e) => setFileSearchResultList(e)}
+              />
+              <FileSearchResultList></FileSearchResultList>
+            </div>
+        }
         {
           !initing && (
             <FileTree
@@ -106,6 +225,7 @@ const Log = (props) => {
               onSelect={onSelectFile}
               activeKey={activeLog}
               defaultActiveKey={activeLog}
+              treeStatusChange={searchTimes}
             />
           )
         }

--- a/assets/src/pages/log/index.less
+++ b/assets/src/pages/log/index.less
@@ -56,3 +56,26 @@
     }
   }
 }
+
+.file-search-bar {
+  width: 212px;
+  margin-top: 10px;
+  outline-style: none;
+  border: 1px solid #ccc; 
+  border-radius: 3px;
+  padding: 2px 5px;
+  &:focus{
+    border-color: #66afe9;
+    outline: 0;
+    -webkit-box-shadow: inset 0 1px 1px rgba(0,0,0,.075),0 0 8px rgba(102,175,233,.6);
+    box-shadow: inset 0 1px 1px rgba(0,0,0,.075),0 0 8px rgba(102,175,233,.6)
+  }
+}
+
+.file-search-result-list {
+  position: absolute;
+  background-color: white;
+  padding-left: 4px;
+  width: 212px;
+  z-index: 100;
+}


### PR DESCRIPTION
### 搜索栏功能概述
1、在输入框中输入一些字符，会查询到文件目录中含有输入字符串的文件/文件夹（提示中匹配的字符会变红），点击该文件/文件夹目录会自动定位到输入框下方文件树中对应目录的位置。（点击文件夹则文件夹自动展开，点击文件则将其父级文件夹自动展开然后定位到对应文件）
![图片](https://user-images.githubusercontent.com/52817273/121399152-be472180-c988-11eb-85b8-9d9ef932bf69.png)
![图片](https://user-images.githubusercontent.com/52817273/121399243-d28b1e80-c988-11eb-9c72-8aa2f9fc04a2.png)(展开的文件夹)

2、如果文件树中没有和输入框中字符串匹配的文件/文件夹，则会提示“没有数据”；如果输入框内容为空，则保证不会进行任何提示。
![图片](https://user-images.githubusercontent.com/52817273/121399482-0bc38e80-c989-11eb-8c58-79b876055182.png)

注：1、由于某些文件目录的设定比较特殊，所以某些比较的地方采用了“特殊”的处理方式。
2、由于文件树默认只支持两层嵌套，文件的定位以及相应文件夹的展开也使用了相应的两层嵌套模式去解决，如果之后想要支持多层嵌套则文件定位的方法也要进行修改。至于搜索功能已经支持多层嵌套递归了就不用修改了。
