### PR TITLE
feat: callremote query timeout

### DIFF
--- a/common/utils.js
+++ b/common/utils.js
@@ -249,9 +249,14 @@ exports.callremote = function (queryPath, options, callback, maxRetry) {
   } else {
     queryPath += '&ips=' + ips;
   }
-  if (options.timeout) {
+  if (options.timeout && !options.queryTimeout) {
     queryPath += '&timeout=' + options.timeout;
   }
+
+  if (options.queryTimeout) {
+    queryPath += '&timeout=' + options.queryTimeout;
+  }
+
   if (endpoint.endsWith('/')) {
     endpoint = endpoint.substring(0, endpoint.length - 1);
   }

--- a/model/cluster.js
+++ b/model/cluster.js
@@ -635,6 +635,7 @@ exports.fixCluster = function (clusterCode, callback) {
   opt.ips = opt.ips.concat(opt.ipsOffline || []);
   opt.clusterCode = clusterCode;
   opt.queryTimeout = 1000;
+  opt.timeout = 2000;
 
   callremoteWithRetry(path, opt, function (err, results) {
     if (err) {

--- a/model/cluster.js
+++ b/model/cluster.js
@@ -634,6 +634,7 @@ exports.fixCluster = function (clusterCode, callback) {
 
   opt.ips = opt.ips.concat(opt.ipsOffline || []);
   opt.clusterCode = clusterCode;
+  opt.queryTimeout = 1000;
 
   callremoteWithRetry(path, opt, function (err, results) {
     if (err) {


### PR DESCRIPTION
timeout 不能和 urllib 的 timeout 重合，因为 `timeout` 传入和 url 的 timeout 的重合之后，就必然会超时